### PR TITLE
Add support for gcc

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -121,7 +121,10 @@ ARG OSX_SDK
 WORKDIR /tmp/osxcross
 COPY --link --from=osxcross-src /osxcross .
 COPY --link --from=sdk /$OSX_SDK.tar.xz ./tarballs/$OSX_SDK.tar.xz
-RUN OSX_VERSION_MIN=10.13 UNATTENDED=1 ENABLE_COMPILER_RT_INSTALL=1 TARGET_DIR=/out/osxcross ./build.sh
+RUN OSX_VERSION_MIN=10.13 UNATTENDED=1 ./build.sh
+RUN OSX_VERSION_MIN=10.13 ./build_gcc.sh
+RUN mkdir -p /out/osxcross
+RUN mv target/* /out/osxcross
 RUN mkdir -p /out/osxsdk/osxsdk
 
 FROM scratch AS build-darwin

--- a/Dockerfile
+++ b/Dockerfile
@@ -114,7 +114,8 @@ RUN apk add --update --no-cache \
   openssl-dev \
   patch \
   python3 \
-  xz
+  xz \
+  wget
 
 FROM base-${BASE_VARIANT} AS build-osxcross
 ARG OSX_SDK


### PR DESCRIPTION
This PR makes it so that the GCC compiler is also built.
I also removed the part of the call to build.sh where it sets ENABLE_COMPILER_RT_INSTALL.
This is because it does nothing when calling build.sh and only works when calling the build_compiler_rt.sh

I would have added support for rt as well, but it didn't work when i tried so i suspect that theres more that needs to be done.